### PR TITLE
fix: configure scaffolder defaults and restrict template to org repos

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -84,6 +84,10 @@ auth:
 
 scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options
+  defaultAuthor:
+    name: Open Service Portal
+    email: noreply@github.com
+  defaultCommitMessage: "Initial commit from Backstage"
 
 catalog:
   import:

--- a/examples/template/template.yaml
+++ b/examples/template/template.yaml
@@ -34,6 +34,8 @@ spec:
           ui:options:
             allowedHosts:
               - github.com
+            allowedOwners:
+              - open-service-portal
 
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.


### PR DESCRIPTION
## Summary
- Add default author and commit message for scaffolder
- Restrict example template to only create repos in open-service-portal org

## Changes
- Added `scaffolder.defaultAuthor` and `scaffolder.defaultCommitMessage` in app-config.yaml
- Added `allowedOwners: [open-service-portal]` to template RepoUrlPicker field

## Why
Prevents permission errors when users try to create repositories outside the organization where the GitHub App is installed.

## Test Plan
- [x] Start Backstage locally
- [x] Create a new service from the example template
- [x] Verify that only "open-service-portal" appears in the Owner dropdown
- [x] Successfully create repository in the organization

🤖 Generated with [Claude Code](https://claude.ai/code)