### PR TITLE
feat: add GitHub template discovery for automatic template import

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -94,7 +94,7 @@ catalog:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration
   rules:
-    - allow: [Component, System, API, Resource, Location, User, Group]
+    - allow: [Component, System, API, Resource, Location, User, Group, Template]
   providers:
     githubOrg:
       - id: production
@@ -103,16 +103,22 @@ catalog:
         schedule:
           frequency: { minutes: 30 }
           timeout: { minutes: 3 }
+    github:
+      templateDiscovery:
+        organization: 'open-service-portal'
+        catalogPath: '/template.yaml'  # Look for template.yaml in repo root
+        filters:
+          repository: '^service-.*-template$'  # Match repos like service-nodejs-template
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }
   locations:
     # Local example data, file locations are relative to the backend process, typically `packages/backend`
     - type: file
       target: ../../examples/entities.yaml
 
-    # Local example template
-    - type: file
-      target: ../../examples/template/template.yaml
-      rules:
-        - allow: [Template]
+    # Templates are now auto-discovered via GitHub provider
+    # Repos matching pattern 'service-*-template' are automatically imported
 
     # Local example organizational data
     - type: file

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.10",
     "@backstage/plugin-auth-node": "^0.6.5",
     "@backstage/plugin-catalog-backend": "^3.0.0",
+    "@backstage/plugin-catalog-backend-module-github": "^0.10.1",
     "@backstage/plugin-catalog-backend-module-logs": "^0.1.12",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "^0.2.10",
     "@backstage/plugin-kubernetes-backend": "^0.19.8",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -32,6 +32,9 @@ backend.add(
 // GitHub Org Entity Provider - imports users and teams from GitHub
 backend.add(import('@backstage/plugin-catalog-backend-module-github-org'));
 
+// GitHub Discovery - automatically discovers repositories matching patterns
+backend.add(import('@backstage/plugin-catalog-backend-module-github'));
+
 // See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors
 backend.add(import('@backstage/plugin-catalog-backend-module-logs'));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15970,6 +15970,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.10"
     "@backstage/plugin-auth-node": "npm:^0.6.5"
     "@backstage/plugin-catalog-backend": "npm:^3.0.0"
+    "@backstage/plugin-catalog-backend-module-github": "npm:^0.10.1"
     "@backstage/plugin-catalog-backend-module-logs": "npm:^0.1.12"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:^0.2.10"
     "@backstage/plugin-kubernetes-backend": "npm:^0.19.8"


### PR DESCRIPTION
## Summary

Implements automatic GitHub template discovery to dynamically import all service templates from the organization.

## Key Changes

### 🔍 GitHub Discovery Module
- Added `@backstage/plugin-catalog-backend-module-github` dependency
- Configured to scan for repositories matching `service-*-template` pattern
- Templates are automatically discovered and imported every 30 minutes

### ⚙️ Configuration Updates
- Added `catalog.providers.github` configuration for template discovery
- Added `Template` to allowed entity types in catalog rules
- Removed manual template location (now auto-discovered)

## Benefits

- ✅ No manual configuration needed for new templates
- ✅ Automatic discovery of all templates following naming convention
- ✅ Templates update automatically on schedule
- ✅ Cleaner configuration without hardcoded URLs

## Testing

1. Created `service-nodejs-template` repository
2. Template automatically discovered via GitHub provider
3. Template appears in Backstage UI at `/create`
4. Successfully tested creating new services from template

## Next Steps

Future templates just need to:
1. Follow naming pattern: `service-*-template`
2. Have `template.yaml` in repository root
3. Will be auto-discovered within 30 minutes (or manual catalog refresh)

🤖 Generated with [Claude Code](https://claude.ai/code)