### PR TITLE
docs: add Docker image build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ yarn test     # Run tests
 yarn lint     # Lint code
 ```
 
+### Docker Image Build
+
+Build and run the application as a Docker container:
+
+```bash
+# Prerequisites: Docker or Rancher Desktop must be running
+
+# Build the backend first (required for Docker image)
+yarn build:backend
+
+# Build the Docker image
+yarn build-image
+
+# Run the container
+docker run -p 7007:7007 backstage
+```
+
+The Docker image:
+- Uses Node.js 20 on Debian Bookworm Slim
+- Includes all production dependencies
+- Exposes port 7007 for the backend API
+- Built as `backstage:latest` by default
+
 ## 📦 Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- Added comprehensive Docker image build documentation to README
- Includes prerequisites, build steps, and running instructions
- Documents image specifications and requirements

## Changes
- Added new "Docker Image Build" section under Development
- Documented the requirement to build backend first (`yarn build:backend`)
- Included commands for building the image (`yarn build-image`)
- Added example for running the container
- Listed key image specifications (Node.js 20, Debian Bookworm Slim, port 7007)

## Test Plan
- [x] Verified build commands work correctly
- [x] Docker image builds successfully after backend build
- [x] Container runs and exposes port 7007
- [x] Documentation is clear and follows existing README style