### PR TITLE
feat: add logging scripts for debugging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ sops updatekeys github-app-key.pem.enc
 ```bash
 # Start development server
 yarn start
+yarn start:log      # With timestamped logging (Unix/Linux/macOS only)
+
+# Installation
+yarn install
+yarn install:log    # With timestamped logging (Unix/Linux/macOS only)
 
 # Build for production
 yarn build:backend
@@ -72,6 +77,12 @@ yarn clean
 # Create new plugin
 yarn new
 ```
+
+### Logging Scripts
+The `:log` variants capture timestamped output for debugging:
+- Default location: `./logs/` 
+- Custom: `BACKSTAGE_LOG_DIR=/path yarn start:log`
+- **Platform:** Unix/Linux/macOS only (uses shell-specific syntax)
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,13 @@ Example: [service-nodejs-template](https://github.com/open-service-portal/servic
 ```bash
 # Development
 yarn start          # Start both frontend and backend
+yarn start:log      # Start with timestamped logging (Unix/Linux/macOS only)
 yarn build:backend  # Build backend only
 yarn build:all      # Build everything for production
+
+# Installation
+yarn install        # Standard installation
+yarn install:log    # Install with timestamped logging (Unix/Linux/macOS only)
 
 # Testing
 yarn test           # Run tests
@@ -98,6 +103,22 @@ yarn fix            # Auto-fix issues
 yarn clean          # Clean build artifacts
 yarn new            # Create new Backstage plugin
 ```
+
+#### Logging Scripts (Unix/Linux/macOS only)
+
+The `yarn start:log` and `yarn install:log` commands capture timestamped logs for debugging:
+
+```bash
+# Default: logs to ./logs directory
+yarn install:log
+yarn start:log
+
+# Custom log directory via environment variable
+BACKSTAGE_LOG_DIR=/tmp yarn start:log
+BACKSTAGE_LOG_DIR=~/debugging yarn install:log
+```
+
+**Note:** These logging scripts use shell-specific syntax and are only compatible with Unix-based systems (Linux, macOS). Windows users should use the standard `yarn start` and `yarn install` commands.
 
 
 ### Environment Variables

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "scripts": {
     "start": "backstage-cli repo start",
+    "start:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && backstage-cli repo start 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/backstage-$(date +%Y%m%d_%H%M%S).log",
+    "install:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && yarn install 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/yarn-install-$(date +%Y%m%d_%H%M%S).log",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build-image": "yarn workspace backend build-image",


### PR DESCRIPTION
## Summary
Adds convenient yarn scripts for capturing timestamped logs during development and debugging.

## Changes
- Add `yarn start:log` - starts Backstage with timestamped logging
- Add `yarn install:log` - runs yarn install with timestamped logging
- Configurable log directory via `BACKSTAGE_LOG_DIR` environment variable
- Default log directory: `./logs` (already in .gitignore)
- Automatically creates log directory if it doesn't exist

## Usage
```bash
# Standard usage (logs to ./logs directory)
yarn install:log
yarn start:log

# Custom log directory
BACKSTAGE_LOG_DIR=/tmp yarn start:log
BACKSTAGE_LOG_DIR=~/debugging yarn install:log
```

## Benefits
- Easier debugging with persistent logs
- Timestamped files prevent overwriting
- Configurable location for different debugging scenarios
- Logs directory already gitignored

/cc @marcelbrueckner @felixboehm FYI