### PR TITLE
feat: add start:openportal script for OpenPortal cluster configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "backstage-cli repo start",
-    "start:openportal": "backstage-cli repo start --config app-config.yaml --config app-config.openportal.local.yaml",
+    "start:openportal": "backstage-cli repo start --config ../../app-config.yaml --config ../../app-config.openportal.local.yaml",
     "start:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && backstage-cli repo start 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/backstage-$(date +%Y%m%d_%H%M%S).log",
     "install:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && yarn install 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/yarn-install-$(date +%Y%m%d_%H%M%S).log",
     "build:backend": "yarn workspace backend build",


### PR DESCRIPTION
## Summary
Add `yarn start:openportal` script to run Backstage with OpenPortal cluster configuration.

## Changes
- Added `start:openportal` script in package.json that loads `app-config.openportal.local.yaml`

## Context
This script works in conjunction with the cluster configuration scripts being added in https://github.com/open-service-portal/portal-workspace/pull/52

The workflow is:
1. Run `./scripts/config-openportal.sh` in portal-workspace to generate `app-config.openportal.local.yaml`
2. Run `yarn start:openportal` in app-portal to start Backstage with OpenPortal cluster config

## Test Plan
- [ ] Run config-openportal.sh to generate config file
- [ ] Run yarn start:openportal
- [ ] Verify Backstage connects to OpenPortal cluster