### PR TITLE
feat: enable direct source loading for kubernetes-ingestor plugin in dev mode

### DIFF
--- a/plugins/kubernetes-ingestor/package.json
+++ b/plugins/kubernetes-ingestor/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@internal/plugin-kubernetes-ingestor",
   "version": "1.19.0",
-  "main": "dist/index.cjs.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",

--- a/plugins/kubernetes-ingestor/src/provider/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/EntityProvider.ts
@@ -122,11 +122,16 @@ export class XRDTemplateEntityProvider implements EntityProvider {
 
       // Fetch all CRDs once
       const crdData = await crdDataProvider.fetchCRDObjects();
+      // Log the number of CRDs fetched
+      this.logger.info(`Ingestor fetched ${crdData.length} CRD objects from clusters`);
 
       if (this.config.getOptionalBoolean('kubernetesIngestor.crossplane.xrds.enabled')) {
         const xrdData = await templateDataProvider.fetchXRDObjects();
+        this.logger.info(`Ingestor fetched ${xrdData.length} XRD objects from clusters`);
         const xrdEntities = xrdData.flatMap(xrd => this.translateXRDVersionsToTemplates(xrd));
+        this.logger.info(`Ingestor found ${xrdEntities.length} XRD Entities`);
         const APIEntities = xrdData.flatMap(xrd => this.translateXRDVersionsToAPI(xrd));
+        this.logger.info(`Ingestor found ${APIEntities.length} XRD API Entities`);
         allEntities = allEntities.concat(xrdEntities, APIEntities);
       }
 
@@ -134,6 +139,8 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       const crdEntities = crdData.flatMap(crd => this.translateCRDToTemplate(crd));
       const CRDAPIEntities = crdData.flatMap(crd => this.translateCRDVersionsToAPI(crd));
       allEntities = allEntities.concat(crdEntities, CRDAPIEntities);
+
+      this.logger.info(`Ingestor found ${allEntities.length} entities`);
 
       await this.connection.applyMutation({
         type: 'full',


### PR DESCRIPTION
## Summary
- Configure kubernetes-ingestor plugin to load from source files (src/index.ts) during development instead of requiring a build step
- Add console logging to XRDTemplateEntityProvider for debugging

## Changes
- Modified `plugins/kubernetes-ingestor/package.json` to point main and types to src/index.ts instead of dist files
- Added debug logging in XRDTemplateEntityProvider to trace XRD processing

## Benefits
- Eliminates the need to run `yarn build` before `yarn start` during plugin development
- Enables hot-reloading and faster development iteration
- Provides better debugging visibility for XRD template generation

## Test Plan
- [x] Run `yarn start` without building the plugin first
- [x] Verify plugin loads correctly from source
- [x] Check console logs show XRD processing information