### PR TITLE
fix: TypeScript dynamic import compatibility for kubernetes-ingestor plugin

### DIFF
--- a/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/KubernetesDataProvider.ts
@@ -148,7 +148,14 @@ export class KubernetesDataProvider {
         // --- BEGIN: Add all v2/Cluster and v2/Namespaced composite kinds (XRs) to objectTypesToFetch ---
         try {
           // Import XrdDataProvider here to avoid circular dependency at top
-          const { XrdDataProvider } = await import('./XrdDataProvider');
+          // Use TypeScript source loading compatible import pattern
+          const XrdDataProviderModule = await import('./XrdDataProvider');
+          
+          // TypeScript source loading puts named exports inside default object
+          const XrdDataProvider = XrdDataProviderModule.XrdDataProvider || 
+                                   XrdDataProviderModule.default?.XrdDataProvider ||
+                                   XrdDataProviderModule.default || 
+                                   XrdDataProviderModule;
           // You may need to pass auth/httpAuth if required by your XrdDataProvider constructor
           const xrdDataProvider = new XrdDataProvider(
             this.logger,


### PR DESCRIPTION
## Summary
Fixes TypeScript dynamic import compatibility issue in the kubernetes-ingestor plugin that prevented XrdDataProvider from loading correctly in development mode.

## Problem
The plugin was failing with:
```
TypeError: XrdDataProvider is not a constructor
```

This occurred because TypeScript source loading (enabled by PR #19) handles named exports differently than compiled JavaScript. The dynamic import pattern used by TeraSky developers worked for compiled code but failed for source loading.

## Root Cause Analysis
When loading TypeScript source files directly:
- Named exports (`export class XrdDataProvider`) are placed inside a `default` object
- The existing import pattern `const { XrdDataProvider } = await import('./XrdDataProvider')` couldn't find the constructor
- Debug logs revealed: `Module keys: default, XrdDataProvider type: undefined, Default type: object`

## Solution
Enhanced the existing dynamic import pattern to handle both scenarios:

```typescript
// TypeScript source loading puts named exports inside default object
const XrdDataProvider = XrdDataProviderModule.XrdDataProvider || 
                         XrdDataProviderModule.default?.XrdDataProvider ||  // ← This fixes TS source loading
                         XrdDataProviderModule.default || 
                         XrdDataProviderModule;
```

## Testing
- ✅ Plugin loads successfully from TypeScript source
- ✅ XrdDataProvider constructor works correctly  
- ✅ XRD ingestion continues normally:
  ```
  Ingestor fetched 4 XRD objects from clusters
  Ingestor found 4 XRD Entities
  Ingestor found 4 XRD API Entities
  Ingestor found 8 entities
  ```

## Context
This complements TeraSky's existing circular dependency avoidance strategy. Their comment "Import XrdDataProvider here to avoid circular dependency at top" shows they anticipated import issues, but didn't account for TypeScript source loading differences.

## Upstream Contribution
This fix addresses a general TypeScript dynamic import pattern that could benefit the broader TeraSky plugin ecosystem. We should consider contributing this enhancement upstream to the original `@terasky/backstage-plugin-kubernetes-ingestor` package.

## Related
- Builds on PR #19 (source loading capability)
- Fixes runtime errors introduced when switching from compiled to source loading
- Maintains backward compatibility with compiled scenarios