### PR TITLE
fix: resolve XrdDataProvider constructor error in dev mode

### DIFF
--- a/plugins/kubernetes-ingestor/src/provider/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/EntityProvider.ts
@@ -1963,7 +1963,9 @@ export class KubernetesEntityProvider implements EntityProvider {
           this.config,
           this.catalogApi,
           this.permissions,
-          this.discovery
+          this.discovery,
+          this.auth,
+          this.httpAuth
         );
 
         let compositeKindLookup: { [key: string]: any } = {};

--- a/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/XrdDataProvider.ts
@@ -27,8 +27,8 @@ export class XrdDataProvider {
   catalogApi: CatalogApi;
   permissions: PermissionEvaluator;
   discovery: DiscoveryService;
-  auth: AuthService;
-  httpAuth: HttpAuthService;
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
 
   private getAnnotationPrefix(): string {
     return (
@@ -43,8 +43,8 @@ export class XrdDataProvider {
     catalogApi: CatalogApi,
     discovery: DiscoveryService,
     permissions: PermissionEvaluator,
-    auth: AuthService,
-    httpAuth: HttpAuthService,
+    auth?: AuthService,
+    httpAuth?: HttpAuthService,
   ) {
     this.logger = logger;
     this.config = config;


### PR DESCRIPTION
## Summary
Fixes the \"XrdDataProvider is not a constructor\" error when running the kubernetes-ingestor plugin in development mode with source files.

## Problem
When using dynamic `import()` with TypeScript source files in dev mode, the module resolution wasn't correctly handling the exported class, resulting in a constructor error.

## Solution
- Replace dynamic `import()` with `require()` for better TypeScript compatibility in dev mode
- Add auth and httpAuth parameters to KubernetesDataProvider class
- Pass auth parameters through the entire provider chain (EntityProvider → KubernetesDataProvider → XrdDataProvider)
- Make auth parameters optional in XrdDataProvider constructor

## Changes
1. **KubernetesDataProvider.ts**:
   - Changed from `await import('./XrdDataProvider')` to `require('./XrdDataProvider')`
   - Added auth and httpAuth class properties and constructor parameters
   - Simplified module resolution logic

2. **XrdDataProvider.ts**:
   - Made auth and httpAuth constructor parameters optional

3. **EntityProvider.ts**:
   - Pass auth and httpAuth when instantiating KubernetesDataProvider

## Test Plan
- [x] Run `yarn start` in dev mode without building the plugin
- [x] Verify XRD objects are fetched without constructor errors
- [x] Check that the plugin loads correctly from source files

## Benefits
- Enables hot-reloading during development
- No need to build the plugin before starting
- Better developer experience with faster iteration