### PR TITLE
fix: remove duplicate Home and Create menu items from sidebar

### DIFF
--- a/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/app/src/modules/nav/Sidebar.tsx
@@ -9,8 +9,6 @@ import { compatWrapper } from '@backstage/core-compat-api';
 import { Sidebar } from '@backstage/core-components';
 import { NavContentBlueprint } from '@backstage/frontend-plugin-api';
 import { SidebarLogo } from './SidebarLogo';
-import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
-import HomeIcon from '@material-ui/icons/Home';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import { SidebarSearchModal } from '@backstage/plugin-search';
@@ -27,15 +25,6 @@ export const SidebarContent = NavContentBlueprint.make({
           </SidebarGroup>
           <SidebarDivider />
           <SidebarGroup label="Menu" icon={<MenuIcon />}>
-            {/* Global nav, not org-specific */}
-            <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
-            <SidebarItem
-              icon={CreateComponentIcon}
-              to="create"
-              text="Create..."
-            />
-            {/* End global nav */}
-            <SidebarDivider />
             <SidebarScrollWrapper>
               {/* Items in this group will be scrollable if they run out of space */}
               {items.map((item, index) => (


### PR DESCRIPTION
## Summary
Removes duplicate hardcoded sidebar menu entries that were also being dynamically generated by plugins.

## Problem
The sidebar had hardcoded "Home" (catalog) and "Create..." menu items that were duplicating the same entries dynamically added by the catalog and scaffolder plugins, resulting in duplicate menu items.

## Solution
- Remove the hardcoded `<SidebarItem>` components for Home and Create
- Keep only the dynamically generated items from plugins
- Clean up unused imports (`HomeIcon` and `CreateComponentIcon`)

## Changes
**packages/app/src/modules/nav/Sidebar.tsx**:
- Removed hardcoded Home and Create menu items
- Removed unused icon imports
- Simplified the Menu group to only contain dynamically generated items

## Result
The sidebar now shows a clean menu without duplicates:
- **Search** - Search functionality
- **Menu** - Contains all plugin-generated items (Home, Create, API, Docs, Kubernetes, etc.)
- **Settings** - User settings

## Test Plan
- [ ] Run `yarn start` and verify sidebar appears correctly
- [ ] Confirm no duplicate Home or Create menu items
- [ ] Verify all plugin navigation items still appear
- [ ] Check that navigation to all menu items works correctly