### PR TITLE
feat: configure catalog-orders repository for XR publishing

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -209,19 +209,20 @@ kubernetesIngestor:
       publishPhase:
         target: github
         git:
-          # repoUrl: github.com?owner=open-service-portal&repo=gitops-manifests-xrd
+          repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
           targetBranch: main
         enabled: true
-        allowRepoSelection: true
+        # allowRepoSelection: true  # Users can override if needed
   genericCRDTemplates:
     # Settings related to the final steps of a software template
     publishPhase:
       allowedTargets: ['github.com']
       target: github
       git:
-        # repoUrl: github.com?owner=open-service-portal&repo=gitops-manifests-crd
+        repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
         targetBranch: main
-      allowRepoSelection: true
+        targetPath: 'crds'  # Put generic CRDs in a subdirectory
+      # allowRepoSelection: true
     # crdLabelSelector:
     #   key: terasky.backstage.io/generate-form
     #   value: "true"


### PR DESCRIPTION
## Summary
Configure Backstage to publish Crossplane XR instances to the catalog-orders repository for GitOps deployment.

## Changes

### XR Template Configuration
```yaml
publishPhase:
  target: github
  git:
    repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
    targetBranch: main
```

### Generic CRD Configuration  
```yaml
publishPhase:
  target: github
  git:
    repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
    targetPath: 'crds'  # Separate subdirectory for generic CRDs
```

## Benefits
- ✅ Consistent GitOps workflow for all XR instances
- ✅ Flux automatically deploys XRs from catalog-orders
- ✅ Clear separation between XRs and generic CRDs
- ✅ Enforces best practices by default

## GitOps Workflow
1. User creates XR via Backstage template
2. XR is committed to catalog-orders repository  
3. Flux detects change and applies to cluster
4. Resource is provisioned automatically

## Testing
After merging:
1. Create a new XR using a Backstage template
2. Verify it's committed to catalog-orders repository
3. Check Flux syncs and applies the resource
4. Confirm resource is created in the cluster

## Related PRs
- portal-workspace #56: Cluster configuration for catalog-orders
- catalog #9: Add namespace template
- template-namespace #1: Namespace template packaging