### PR TITLE
feat: add catalog source tagger module for automatic entity tagging

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -41,6 +41,9 @@ backend.add(
 backend.add(import('@backstage/plugin-catalog-backend-module-github'));
 backend.add(import('@backstage/plugin-catalog-backend-module-github-org'));
 
+// Custom catalog module for automatic source tagging
+backend.add(import('../../../plugins/catalog-backend-module-source-tagger/src/index.ts'));
+
 // See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors
 backend.add(import('@backstage/plugin-catalog-backend-module-logs'));
 

--- a/plugins/catalog-backend-module-source-tagger/README.md
+++ b/plugins/catalog-backend-module-source-tagger/README.md
@@ -1,0 +1,149 @@
+# Catalog Backend Module: Source Tagger
+
+A Backstage 1.42+ compatible backend module that automatically adds metadata tags to catalog entities based on their import source.
+
+## Compatibility
+
+- **Backstage Version**: 1.42.0+
+- **Backend System**: New Backend System
+- **Module Type**: Catalog Processor Module
+
+## Features
+
+Automatically adds tags to Templates and other entities:
+- `source:github-discovered` - for entities discovered via GitHub discovery
+- `source:github-url` - for entities imported via direct GitHub URLs
+- `org:<orgname>` - organization tags extracted from GitHub URLs
+- `official` - for entities from the open-service-portal organization
+- `auto-discovered` - for entities found via automatic discovery
+
+Also adds annotations:
+- `backstage.io/source-location` - the original import location
+- `backstage.io/discovered-at` - timestamp when the entity was discovered
+
+## Installation
+
+### 1. Add the module to your backend
+
+```typescript
+// packages/backend/src/index.ts
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+// ... other plugins
+
+backend.add(import('@backstage/plugin-catalog-backend'));
+backend.add(import('../../plugins/catalog-backend-module-source-tagger')); // Add this line
+
+backend.start();
+```
+
+### 2. Configuration (Optional)
+
+```yaml
+# app-config.yaml
+catalog:
+  processors:
+    sourceTagger:
+      enabled: true  # Default: true, set to false to disable
+```
+
+## How it works
+
+The `SourceTagProcessor` implements the Backstage `CatalogProcessor` interface and:
+1. Examines the location spec of each entity being imported
+2. Determines the source based on location type and URL patterns
+3. Adds appropriate tags without modifying existing ones
+4. Logs tag additions for debugging (when logger is in debug mode)
+5. Removes duplicate tags in post-processing
+
+### Technical Implementation
+
+- **Processor**: `SourceTagProcessor` class implementing `CatalogProcessor`
+- **Module**: Uses `createBackendModule` (New Backend System)
+- **Dependencies**: 
+  - `catalogProcessingExtensionPoint` - to register the processor
+  - `coreServices.logger` - for logging
+  - `coreServices.rootConfig` - for configuration
+- **Hooks**: `preProcessEntity` and `postProcessEntity`
+
+## Extending
+
+### Adding Custom Tagging Rules
+
+Modify the `SourceTagProcessor.ts` file:
+
+```typescript
+// Add custom organization tags
+if (org === 'your-org') {
+  tags.add('your-custom-tag');
+}
+
+// Add tags based on location type
+if (location.type === 'gitlab-discovery') {
+  tags.add('source:gitlab-discovered');
+}
+```
+
+### Creating Your Own Module
+
+To create a similar module for your own use case:
+
+```bash
+# From your Backstage project root
+yarn new
+# Select: backend-module
+# Plugin ID: catalog
+# Module ID: your-processor-name
+```
+
+## Why not hardcode tags?
+
+Hardcoding `source:github-discovered` in each template.yaml file:
+- Requires manual maintenance
+- Can be forgotten when creating new templates
+- Doesn't scale well
+- Can't be changed retroactively
+
+With this processor:
+- Tags are added automatically
+- Consistent across all imports
+- Can be changed centrally
+- Works for future templates without modification
+
+## Debugging
+
+Enable debug logging to see when tags are added:
+
+```yaml
+# app-config.yaml
+backend:
+  logger:
+    catalog: debug
+```
+
+Then check the logs:
+```
+[catalog] Added tags to Template:service-nodejs-template: source:github-discovered, org:open-service-portal
+```
+
+## Architecture
+
+This module follows the Backstage 1.42+ New Backend System architecture:
+
+```
+Backend
+  ├── Catalog Plugin
+  │   ├── Processing Pipeline
+  │   │   └── SourceTagProcessor (this module)
+  │   └── Extension Points
+  │       └── catalogProcessingExtensionPoint
+  └── Core Services
+      ├── Logger Service
+      └── Config Service
+```
+
+## License
+
+Apache 2.0

--- a/plugins/catalog-backend-module-source-tagger/README.md
+++ b/plugins/catalog-backend-module-source-tagger/README.md
@@ -18,7 +18,7 @@ Automatically adds tags to Templates and other entities:
 - `auto-discovered` - for entities found via automatic discovery
 
 Also adds annotations:
-- `backstage.io/source-location` - the original import location
+- `backstage.io/source-location` - the original import location (only for URL-based imports, not for kubernetes-ingestor)
 - `backstage.io/discovered-at` - timestamp when the entity was discovered
 
 ## Installation
@@ -57,6 +57,18 @@ The `SourceTagProcessor` implements the Backstage `CatalogProcessor` interface a
 3. Adds appropriate tags without modifying existing ones
 4. Logs tag additions for debugging (when logger is in debug mode)
 5. Removes duplicate tags in post-processing
+
+### Location Types Handled
+
+- **URL-based locations** (e.g., `url:https://github.com/...`):
+  - Sets `backstage.io/source-location` annotation
+  - Adds source tags like `source:github-discovered` or `source:github-url`
+  - Extracts organization tags from URLs
+
+- **Kubernetes-ingestor locations** (e.g., `cluster origin: rancher-desktop`):
+  - Does NOT set `backstage.io/source-location` (prevents scaffolder errors)
+  - Source tags handled by kubernetes-ingestor plugin itself
+  - Only adds `backstage.io/discovered-at` timestamp
 
 ### Technical Implementation
 

--- a/plugins/catalog-backend-module-source-tagger/package.json
+++ b/plugins/catalog-backend-module-source-tagger/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@internal/plugin-catalog-backend-module-source-tagger",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module",
+    "pluginId": "catalog",
+    "moduleId": "source-tagger"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "^1.4.1",
+    "@backstage/catalog-model": "^1.7.5",
+    "@backstage/plugin-catalog-common": "^1.1.0",
+    "@backstage/plugin-catalog-node": "^1.17.2"
+  },
+  "devDependencies": {
+    "@backstage/backend-test-utils": "^1.7.0",
+    "@backstage/cli": "^0.33.1",
+    "typescript": "^5.8.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/catalog-backend-module-source-tagger/src/index.ts
+++ b/plugins/catalog-backend-module-source-tagger/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @packageDocumentation
+ * 
+ * Catalog Backend Module for automatic source tagging of entities.
+ * 
+ * This module provides a processor that automatically adds metadata tags
+ * to catalog entities based on their import source (GitHub, Kubernetes, etc.)
+ */
+
+export { catalogModuleSourceTagger as default } from './module';
+
+// Export the processor for testing or direct use
+export { SourceTagProcessor } from './processor/SourceTagProcessor';

--- a/plugins/catalog-backend-module-source-tagger/src/module.ts
+++ b/plugins/catalog-backend-module-source-tagger/src/module.ts
@@ -1,0 +1,40 @@
+import { 
+  createBackendModule,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { SourceTagProcessor } from './processor/SourceTagProcessor';
+
+/**
+ * Catalog module that adds automatic source tagging to entities.
+ * 
+ * This module registers a processor that automatically adds tags based on 
+ * where entities are imported from (GitHub, Kubernetes, etc.)
+ */
+export const catalogModuleSourceTagger = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'source-tagger',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogProcessingExtensionPoint,
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+      },
+      async init({ catalog, logger, config }) {
+        // Check if module is enabled (optional configuration)
+        const isEnabled = config.getOptionalBoolean('catalog.processors.sourceTagger.enabled') ?? true;
+        
+        if (!isEnabled) {
+          logger.info('SourceTagProcessor is disabled via configuration');
+          return;
+        }
+        
+        // Register our custom processor
+        catalog.addProcessor(new SourceTagProcessor(logger));
+        
+        logger.info('SourceTagProcessor registered - will auto-tag entities based on import source');
+      },
+    });
+  },
+});

--- a/plugins/catalog-backend-module-source-tagger/src/processor/SourceTagProcessor.ts
+++ b/plugins/catalog-backend-module-source-tagger/src/processor/SourceTagProcessor.ts
@@ -66,11 +66,16 @@ export class SourceTagProcessor implements CatalogProcessor {
     }
 
     // Add discovery timestamp as annotation (not tag)
-    const annotations = {
+    // Only add source-location if it's a URL (not for kubernetes origins)
+    const annotations: Record<string, string> = {
       ...entity.metadata.annotations,
-      'backstage.io/source-location': location.target || 'unknown',
       'backstage.io/discovered-at': new Date().toISOString(),
     };
+    
+    // Only set source-location for URL-based locations
+    if (location.type === 'url' && location.target) {
+      annotations['backstage.io/source-location'] = location.target;
+    }
 
     // Log the tagging for debugging (only in debug mode)
     if (tags.size > existingTags.length) {

--- a/plugins/catalog-backend-module-source-tagger/src/processor/SourceTagProcessor.ts
+++ b/plugins/catalog-backend-module-source-tagger/src/processor/SourceTagProcessor.ts
@@ -1,0 +1,104 @@
+import { 
+  CatalogProcessor, 
+  CatalogProcessorEmit,
+  processingResult
+} from '@backstage/plugin-catalog-node';
+import { Entity } from '@backstage/catalog-model';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+/**
+ * A processor that automatically adds source tags to entities based on their import location.
+ * 
+ * This processor adds tags like:
+ * - source:github-discovered - for templates discovered via GitHub discovery
+ * - source:github-url - for direct GitHub URLs
+ * - org:<orgname> - organization tags based on GitHub URL
+ * 
+ * Note: The kubernetes-ingestor plugin already adds source:kubernetes-ingestor
+ */
+export class SourceTagProcessor implements CatalogProcessor {
+  constructor(private readonly logger: LoggerService) {}
+
+  getProcessorName(): string {
+    return 'SourceTagProcessor';
+  }
+
+  async preProcessEntity(
+    entity: Entity,
+    location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<Entity> {
+    // Only process Templates for now (can be extended to other kinds)
+    if (entity.kind !== 'Template') {
+      return entity;
+    }
+
+    // Start with existing tags or empty array
+    const existingTags = entity.metadata.tags || [];
+    const tags = new Set(existingTags);
+    
+    // Check if this comes from GitHub discovery
+    // GitHub discovery sets type as 'url' but we can detect it by checking for template.yaml pattern
+    const isGithubDiscovery = location.type === 'url' && 
+                              location.target?.includes('github.com') && 
+                              location.target?.includes('/template.yaml');
+    
+    if (isGithubDiscovery) {
+      tags.add('source:github-discovered');
+      tags.add('auto-discovered');
+    } 
+    // Check if this is a direct GitHub URL (not from discovery)
+    else if (location.type === 'url' && location.target?.includes('github.com')) {
+      tags.add('source:github-url');
+    }
+    
+    // Extract organization from GitHub URLs
+    const githubMatch = location.target?.match(/github\.com\/([^\/]+)/);
+    if (githubMatch) {
+      const org = githubMatch[1];
+      tags.add(`org:${org}`);
+      
+      // Add specific tags for known organizations
+      if (org === 'open-service-portal') {
+        tags.add('official');
+      }
+    }
+
+    // Add discovery timestamp as annotation (not tag)
+    const annotations = {
+      ...entity.metadata.annotations,
+      'backstage.io/source-location': location.target || 'unknown',
+      'backstage.io/discovered-at': new Date().toISOString(),
+    };
+
+    // Log the tagging for debugging (only in debug mode)
+    if (tags.size > existingTags.length) {
+      const newTags = Array.from(tags).filter(t => !existingTags.includes(t));
+      this.logger.debug(`Added tags to ${entity.kind}:${entity.metadata.name}: ${newTags.join(', ')}`);
+    }
+
+    // Return entity with updated metadata
+    return {
+      ...entity,
+      metadata: {
+        ...entity.metadata,
+        tags: Array.from(tags),
+        annotations,
+      },
+    };
+  }
+
+  // Optional: Post-process to validate tags
+  async postProcessEntity(
+    entity: Entity,
+    location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<Entity> {
+    // Remove duplicate tags if any
+    if (entity.metadata.tags) {
+      entity.metadata.tags = [...new Set(entity.metadata.tags)];
+    }
+    return entity;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4420,7 +4420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:^1.1.1, @backstage/plugin-catalog-common@npm:^1.1.5":
+"@backstage/plugin-catalog-common@npm:^1.1.0, @backstage/plugin-catalog-common@npm:^1.1.1, @backstage/plugin-catalog-common@npm:^1.1.5":
   version: 1.1.5
   resolution: "@backstage/plugin-catalog-common@npm:1.1.5"
   dependencies:
@@ -7619,6 +7619,20 @@ __metadata:
   checksum: 10c0/1171bffb9ea0018b12ec4f46a7b485f7e2a328e620e89f3b03f2be8c25889e5b9e62daca3ea10ed040a71d847066c4d9879dc1fea8aa5690ebbc968d3254a5ac
   languageName: node
   linkType: hard
+
+"@internal/plugin-catalog-backend-module-source-tagger@workspace:plugins/catalog-backend-module-source-tagger":
+  version: 0.0.0-use.local
+  resolution: "@internal/plugin-catalog-backend-module-source-tagger@workspace:plugins/catalog-backend-module-source-tagger"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.4.1"
+    "@backstage/backend-test-utils": "npm:^1.7.0"
+    "@backstage/catalog-model": "npm:^1.7.5"
+    "@backstage/cli": "npm:^0.33.1"
+    "@backstage/plugin-catalog-common": "npm:^1.1.0"
+    "@backstage/plugin-catalog-node": "npm:^1.17.2"
+    typescript: "npm:^5.8.3"
+  languageName: unknown
+  linkType: soft
 
 "@internal/plugin-kubernetes-ingestor@link:../../plugins/kubernetes-ingestor::locator=backend%40workspace%3Apackages%2Fbackend":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Summary
Custom Backstage catalog processor plugin that automatically adds source tags to entities based on their import location.

## Features
- 🏷️ Automatically adds source tags (`source:github-discovered`, `source:github-url`, etc.)
- 🏢 Organization tags from GitHub URLs (`org:open-service-portal`)
- ⭐ Special tags for known organizations (`official` for open-service-portal)
- 📝 Annotations for source tracking and discovery timestamps
- 🔧 Configurable via app-config.yaml
- 🐛 **FIX**: Prevents scaffolder errors by only setting source-location for URL-based imports

## Changes

### New Features
1. **SourceTagProcessor** - Catalog processor that adds tags based on import source
2. **Backend Module** - Backstage 1.42+ compatible module using New Backend System
3. **Automatic Tag Detection**:
   - GitHub discovery vs direct URL imports
   - Organization extraction from URLs
   - Special handling for official repositories

### Bug Fixes (added in latest commits)
1. **Fixed scaffolder error "Unable to parse location ref"**:
   - Only sets `backstage.io/source-location` annotation for URL-based locations
   - Skips annotation for kubernetes-ingestor origins (e.g., `rancher-desktop`)
   - Prevents invalid location references in scaffolder

### Documentation
- Comprehensive README with installation and configuration instructions
- Examples of extending the processor with custom rules
- Architecture explanation following Backstage 1.42+ patterns
- **Updated**: Clarified location type handling (URL vs kubernetes-ingestor)

## Technical Implementation
- Uses Backstage New Backend System (`createBackendModule`)
- Implements `CatalogProcessor` interface
- Hooks: `preProcessEntity` and `postProcessEntity`
- Dependency injection with `coreServices`
- Full TypeScript with proper typing

## Testing
```bash
# Start Backstage
cd app-portal
yarn start

# Check templates at http://localhost:3000/create
# Templates should show appropriate source tags:
# - source:github-discovered (for auto-discovered templates)
# - source:github-url (for manually imported)
# - source:kubernetes-ingestor (from k8s, handled by that plugin)

# Verify scaffolder works without errors
# (Previously failed with "Unable to parse location ref 'rancher-desktop'")
```

## Configuration
```yaml
# app-config.yaml
catalog:
  processors:
    sourceTagger:
      enabled: true  # Default: true
```

## Files Changed
- `plugins/catalog-backend-module-source-tagger/` - New plugin module
  - `src/processor/SourceTagProcessor.ts` - Main processor implementation
  - `src/module.ts` - Backend module registration
  - `src/index.ts` - Public exports
  - `package.json` - Dependencies
  - `README.md` - Documentation
- `packages/backend/src/index.ts` - Module registration

## Breaking Changes
None - this is purely additive.

## Related Issues
- Fixes scaffolder error when using kubernetes-ingestor templates
- Resolves issue with hardcoded `source:github-import` tags in templates

🤖 Generated with [Claude Code](https://claude.ai/code)