### PR TITLE
fix: exclude system namespaces from kubernetes-ingestor

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -191,6 +191,11 @@ kubernetesIngestor:
       - flux-system
       - crossplane-system
       - backstage-system
+      - calico-system
+      - calico-apiserver
+      - tigera-operator
+      - ingress-nginx
+      - kubernetes-dashboard
   
   # Crossplane XRD template generation
   crossplane:


### PR DESCRIPTION
## Summary
Excludes infrastructure and system namespaces from being auto-ingested into the Backstage catalog by the kubernetes-ingestor plugin.

## Problem
The Backstage catalog was cluttered with infrastructure components that developers don't need to see:
- Calico networking components (4 items)
- tigera-operator
- ingress-nginx-controller
- kubernetes-dashboard

## Solution
Added these namespaces to the `excludedNamespaces` configuration in `app-config.yaml`:
- `calico-system` - CNI networking components
- `calico-apiserver` - CNI API server
- `tigera-operator` - Calico operator
- `ingress-nginx` - Ingress controller
- `kubernetes-dashboard` - Kubernetes management UI

## Impact
- **Before**: 9 components in catalog (mostly infrastructure)
- **After**: Only application workloads and Crossplane XRs visible
- Cleaner, more focused catalog for developers
- Infrastructure components no longer clutter the view

## Testing
After applying this change and restarting Backstage:
1. System components will no longer be ingested
2. Existing system components will be removed on next sync (within 10 seconds)
3. Only application workloads in non-system namespaces will appear

## Additional Cleanup
Also removed the `podinfo` test deployment from the cluster:
```bash
kubectl delete deployment podinfo -n default
kubectl delete service podinfo -n default
```