### PR TITLE
feat: add dynamic start script with kubectl context detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,10 @@ sops updatekeys github-app-key.pem.enc
 ## Development Commands
 
 ```bash
-# Start development server
-yarn start
-yarn start:log      # With timestamped logging (Unix/Linux/macOS only)
+# Start development server (auto-detects kubectl context)
+yarn start              # Loads app-config.{context}.local.yaml automatically
+yarn start:log          # Same as above, with timestamped logging
+yarn start --log        # Alternative syntax for logging
 
 # Installation
 yarn install
@@ -80,11 +81,24 @@ yarn clean
 yarn new
 ```
 
-### Logging Scripts
-The `:log` variants capture timestamped output for debugging:
-- Default location: `./logs/` 
-- Custom: `BACKSTAGE_LOG_DIR=/path yarn start:log`
-- **Platform:** Unix/Linux/macOS only (uses shell-specific syntax)
+### Dynamic Start Script
+
+The `yarn start` command uses a Node.js script (`start.js` in root) that:
+1. Detects current kubectl context via `kubectl config current-context`
+2. Looks for context-specific config: `app-config.{context}.local.yaml`
+3. Automatically loads both base and context configs
+4. Shows which configuration is being used
+5. Falls back gracefully if no context or config found
+
+**Example:**
+- Context: `rancher-desktop` → Loads: `app-config.rancher-desktop.local.yaml`
+- Context: `rackspace-openportal` → Loads: `app-config.rackspace-openportal.local.yaml`
+
+### Logging Support
+The start script supports logging via `--log` flag:
+- Creates timestamped log files in `./logs/` directory
+- Custom location: `BACKSTAGE_LOG_DIR=/path yarn start:log`
+- Captures both stdout and stderr for debugging
 
 ## 🆕 New Frontend System Architecture (v1.42.0)
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ yarn install
 # Allow direnv to load environment (auto-decrypts secrets)
 direnv allow
 
-# Start the application
-yarn start
+# Start the application (auto-detects kubectl context)
+yarn start        # Using yarn (traditional Node.js way)
+# OR
+./start.js        # Direct execution (Unix-style) 🚀
 ```
+
+The application automatically detects your current kubectl context and loads the appropriate configuration file (e.g., `app-config.rancher-desktop.local.yaml` for local development).
 
 The secrets are automatically decrypted using SOPS when you enter the directory with direnv. Your SSH key is used for decryption - no additional configuration needed!
 
@@ -80,9 +84,17 @@ Example: [service-nodejs-template](https://github.com/open-service-portal/servic
 ### Commands
 
 ```bash
-# Development
-yarn start          # Start both frontend and backend
-yarn start:log      # Start with timestamped logging (Unix/Linux/macOS only)
+# Development - Choose your style!
+
+# Traditional Node.js style
+yarn start          # Start with auto-detected kubectl context config
+yarn start:log      # Same as above, with timestamped logging
+
+# Direct execution (Unix-style)
+./start.js          # Start with auto-detected config
+./start.js --log    # With timestamped logging
+
+# Build commands
 yarn build:backend  # Build backend only
 yarn build:all      # Build everything for production
 
@@ -106,9 +118,22 @@ yarn clean          # Clean build artifacts
 yarn new            # Create new Backstage plugin
 ```
 
-#### Logging Scripts (Unix/Linux/macOS only)
+#### Dynamic Configuration Loading
 
-The `yarn start:log` and `yarn install:log` commands capture timestamped logs for debugging:
+Both `yarn start` and `./start` automatically detect your current kubectl context and load the matching configuration:
+- Detects context via `kubectl config current-context`
+- Loads `app-config.{context}.local.yaml` if it exists
+- Falls back to base `app-config.yaml` if no context-specific config found
+- Shows which configuration is being used during startup
+
+#### Logging Scripts
+
+Logging can be enabled through multiple methods:
+- `yarn start:log` - Using yarn script
+- `./start.js --log` - Direct execution with flag
+- `yarn install:log` - For installation logging
+
+These commands capture timestamped logs for debugging:
 
 ```bash
 # Default: logs to ./logs directory
@@ -152,7 +177,7 @@ packages/
 
 - `app-config.yaml` - Base configuration (Updated for v1.42.0)
 - `app-config.production.yaml` - Production overrides
-- `app-config.local.yaml` - Local overrides (gitignored) with New Backend System
+- `app-config.{context}.local.yaml` - Context-specific overrides (gitignored, auto-loaded by yarn start)
 - `.sops.yaml` - SOPS encryption configuration
 - `.envrc` - Direnv auto-loader with SOPS decryption
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -195,6 +195,7 @@ kubernetesIngestor:
       - calico-apiserver
       - tigera-operator
       - ingress-nginx
+      - external-dns
       - kubernetes-dashboard
   
   # Crossplane XRD template generation

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "node": "20 || 22"
   },
   "scripts": {
-    "start": "backstage-cli repo start",
-    "start:openportal": "backstage-cli repo start --config ../../app-config.yaml --config ../../app-config.openportal.local.yaml",
-    "start:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && backstage-cli repo start 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/backstage-$(date +%Y%m%d_%H%M%S).log",
+    "start": "node start.js",
+    "start:log": "node start.js --log",
+    "start:default": "backstage-cli repo start",
+    "start:default:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && backstage-cli repo start 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/backstage-$(date +%Y%m%d_%H%M%S).log",
     "install:log": "mkdir -p ${BACKSTAGE_LOG_DIR:-logs} && yarn install 2>&1 | tee ${BACKSTAGE_LOG_DIR:-logs}/yarn-install-$(date +%Y%m%d_%H%M%S).log",
     "build:plugins": "yarn workspace @internal/plugin-kubernetes-ingestor tsc && yarn workspace @internal/plugin-kubernetes-ingestor build",
     "build:backend": "yarn build:plugins && yarn workspace backend build",

--- a/start.js
+++ b/start.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Dynamic Backstage starter with logging support
+ * Usage: 
+ *   yarn start              - Auto-detect context and start
+ *   yarn start --log        - Auto-detect context and start with logging
+ *   yarn start:log          - Same as yarn start --log
+ */
+
+const { execSync, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Check for --log flag
+const withLogging = process.argv.includes('--log') || process.argv.includes('--with-log');
+
+// Get current kubectl context
+let context;
+try {
+  context = execSync('kubectl config current-context', { encoding: 'utf8' }).trim();
+  console.log(`📍 Current kubectl context: ${context}`);
+} catch (error) {
+  console.log('⚠️  No kubectl context found, using defaults');
+  context = null;
+}
+
+// Ensure we're in the right directory (app-portal root)
+const appPortalRoot = __dirname;
+process.chdir(appPortalRoot);
+console.log(`📂 Working directory: ${process.cwd()}`);
+
+// Build the backstage command
+const backstageArgs = ['backstage-cli', 'repo', 'start'];
+
+// Always add the base config with absolute path
+const baseConfigPath = path.join(appPortalRoot, 'app-config.yaml');
+if (!fs.existsSync(baseConfigPath)) {
+  console.error(`❌ Error: Base config not found at ${baseConfigPath}`);
+  process.exit(1);
+}
+backstageArgs.push('--config', baseConfigPath);
+
+if (context) {
+  const configFile = `app-config.${context}.local.yaml`;
+  const configPath = path.join(appPortalRoot, configFile);
+  
+  if (fs.existsSync(configPath)) {
+    console.log(`✅ Found config: ${configFile}`);
+    backstageArgs.push('--config', configPath);
+  } else {
+    console.log(`⚠️  No config found for context: ${context}`);
+    console.log(`    Expected: ${configFile}`);
+    console.log('    Using base configuration only');
+  }
+}
+
+// Prepare command and logging
+let command, commandArgs, spawnOptions;
+
+if (withLogging) {
+  const logDir = process.env.BACKSTAGE_LOG_DIR || 'logs';
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+  const logFile = path.join(logDir, `backstage-${timestamp}.log`);
+  
+  console.log(`📝 Logging enabled: ${logFile}`);
+  
+  // Create log directory if it doesn't exist
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+  
+  // Build the full command with logging using shell
+  command = `yarn ${backstageArgs.join(' ')} 2>&1 | tee ${logFile}`;
+  commandArgs = [];
+  spawnOptions = { stdio: 'inherit', shell: true };
+  console.log('🚀 Starting Backstage with logging...\n');
+} else {
+  // Simple command without logging
+  command = 'yarn';
+  commandArgs = backstageArgs;
+  spawnOptions = { stdio: 'inherit', shell: true };
+  console.log('🚀 Starting Backstage...\n');
+}
+
+// Start the process
+const child = spawn(command, commandArgs, spawnOptions);
+
+child.on('error', (error) => {
+  console.error('Failed to start Backstage:', error);
+  process.exit(1);
+});
+
+child.on('exit', (code) => {
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary

This PR adds a dynamic start script that automatically detects the current kubectl context and loads the appropriate Backstage configuration file, eliminating the need to manually specify which environment configuration to use.

## Key Features

- **Auto-detection**: Detects kubectl context via `kubectl config current-context`
- **Context-specific configs**: Loads `app-config.{context}.local.yaml` automatically
- **Direct execution**: Script can be run directly as `./start.js` (Unix-style)
- **Logging support**: Built-in logging via `--log` flag or `yarn start:log`
- **Improved visibility**: Script moved to root directory for better discoverability

## Changes

- Created `start.js` - Dynamic Node.js script with context detection
- Updated `package.json` to reference new script location
- Enhanced README with both yarn and direct execution methods
- Updated CLAUDE.md with detailed documentation
- Added `external-dns` to ignored namespaces in kubernetes ingestor

## Usage

```bash
# Traditional Node.js style
yarn start          # Auto-detects context
yarn start:log      # With logging

# Direct execution (Unix-style) 
./start.js          # Auto-detects context
./start.js --log    # With logging
```

## Example Output

```
📍 Current kubectl context: rancher-desktop
📂 Working directory: /Users/felix/work/open-service-portal/portal-workspace/app-portal
✅ Found config: app-config.rancher-desktop.local.yaml
🚀 Starting Backstage...
```

## Benefits

- **Seamless context switching**: No manual config updates when switching between clusters
- **Better developer experience**: Clear feedback about which config is being used
- **Flexibility**: Multiple invocation methods to suit different preferences
- **Maintainability**: Cleaner, deduplicated code with single execution path

## Testing

1. Switch kubectl context: `kubectl config use-context rancher-desktop`
2. Run: `./start.js` or `yarn start`
3. Verify it loads `app-config.rancher-desktop.local.yaml`
4. Switch to another context and verify it loads the appropriate config

This significantly improves the developer experience when working with multiple Kubernetes clusters.