### PR TITLE
feat: add demo as default namespace for XR templates

### DIFF
--- a/plugins/kubernetes-ingestor/src/provider/EntityProvider.ts
+++ b/plugins/kubernetes-ingestor/src/provider/EntityProvider.ts
@@ -540,10 +540,11 @@ export class XRDTemplateEntityProvider implements EntityProvider {
       mainParameterGroup.required.push('xrNamespace');
       mainParameterGroup.properties.xrNamespace = {
         title: 'Namespace',
-        description: 'The namespace in which to create the resource',
+        description: 'The namespace in which to create the resource (default: demo)',
         pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
         maxLength: 63,
         type: 'string',
+        default: 'demo',  // Default namespace for convenience
       };
     }
     mainParameterGroup.properties.owner = {


### PR DESCRIPTION
## Summary

Adds `demo` as the default namespace value for XR templates in the Kubernetes Ingestor plugin.

## Changes

- Sets `demo` as default value in the namespace field
- Updates field description to indicate the default value: "(default: demo)"

## Benefits

- **Improved UX**: Users don't need to type "demo" every time
- **Faster resource creation**: One less field to fill out
- **Maintains flexibility**: Users can still override with any namespace
- **Consistent with cluster setup**: The `demo` namespace is automatically created by `cluster-config.sh`

## Testing

- The default value appears in Backstage template forms
- Users can override the default if needed
- No breaking changes - purely additive improvement