### PR TITLE
docs: add API access documentation for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,31 @@ The start script supports logging via `--log` flag:
 - Custom location: `BACKSTAGE_LOG_DIR=/path yarn start:log`
 - Captures both stdout and stderr for debugging
 
+## API Access for Claude Code
+
+Claude Code can access Backstage programmatically using the API token configured for each environment:
+
+**Finding the API token:**
+```bash
+# Token is stored in the context-specific config file
+grep "token:" app-config.*.local.yaml | grep static
+# Location: app-config.{context}.local.yaml under backend.auth.externalAccess[].options.token
+```
+
+**Using the API:**
+```bash
+# Extract token from config file
+TOKEN=$(grep -A2 "type: static" app-config.openportal.local.yaml | grep "token:" | awk '{print $2}')
+
+# Access catalog entities
+curl -H "Authorization: Bearer $TOKEN" http://localhost:7007/api/catalog/entities
+
+# Filter for specific entity types
+curl -H "Authorization: Bearer $TOKEN" "http://localhost:7007/api/catalog/entities?filter=kind=Template"
+```
+
+The API provides read access to all catalog entities including templates, components, and systems.
+
 ## 🆕 New Frontend System Architecture (v1.42.0)
 
 This app uses Backstage's **New Frontend System** with significant architecture changes:


### PR DESCRIPTION
## Summary

This PR adds documentation to CLAUDE.md explaining how Claude Code can programmatically access the Backstage API using the configured tokens.

## Changes

- Added new section "API Access for Claude Code" in CLAUDE.md
- Documented how to find and extract API tokens from app-config files
- Provided examples of using curl with Bearer authentication
- Explained available API endpoints for accessing catalog entities

## Purpose

This documentation helps Claude Code understand how to:
- Locate the API tokens in configuration files
- Extract tokens dynamically without hardcoding
- Use the tokens to query Backstage catalog data
- Access templates, components, and other entities programmatically

## Testing

The API access was tested and verified to work with:
- ✅ Retrieving all catalog entities (38 entities found)
- ✅ Filtering for templates (11 templates accessible)
- ✅ Getting specific entity details
- ✅ Bearer token authentication working correctly