### PR TITLE
feat: hide Lifecycle column in catalog table

### DIFF
--- a/packages/app/src/hideLifecycle.js
+++ b/packages/app/src/hideLifecycle.js
@@ -1,0 +1,23 @@
+// Minimal script to hide Lifecycle column
+// Find and hide by text content (more reliable than nth-child)
+
+function hideLifecycle() {
+  document.querySelectorAll('th').forEach((th, index) => {
+    if (th.textContent?.trim() === 'Lifecycle') {
+      // Hide header
+      th.style.display = 'none';
+      
+      // Hide all cells in this column
+      const table = th.closest('table');
+      table?.querySelectorAll('tr').forEach(row => {
+        const cell = row.children[index];
+        if (cell) cell.style.display = 'none';
+      });
+    }
+  });
+}
+
+// Run on load and DOM changes
+hideLifecycle();
+new MutationObserver(() => setTimeout(hideLifecycle, 50))
+  .observe(document.body, { childList: true, subtree: true });

--- a/packages/app/src/hideLifecycle.js
+++ b/packages/app/src/hideLifecycle.js
@@ -4,7 +4,7 @@
 let hideTimeout;
 
 function hideLifecycle() {
-  document.querySelectorAll('table:not([data-processed])').forEach(table => {
+  document.querySelectorAll('table').forEach(table => {
     const ths = table.querySelectorAll('th');
     let lifecycleIndex = -1;
     
@@ -21,8 +21,6 @@ function hideLifecycle() {
         if (cell) cell.style.display = 'none';
       });
     }
-    
-    table.dataset.processed = "1";
   });
 }
 

--- a/packages/app/src/hideLifecycle.js
+++ b/packages/app/src/hideLifecycle.js
@@ -1,23 +1,34 @@
 // Minimal script to hide Lifecycle column
 // Find and hide by text content (more reliable than nth-child)
 
+let hideTimeout;
+
 function hideLifecycle() {
-  document.querySelectorAll('th').forEach((th, index) => {
-    if (th.textContent?.trim() === 'Lifecycle') {
-      // Hide header
-      th.style.display = 'none';
-      
-      // Hide all cells in this column
-      const table = th.closest('table');
-      table?.querySelectorAll('tr').forEach(row => {
-        const cell = row.children[index];
+  document.querySelectorAll('table:not([data-processed])').forEach(table => {
+    const ths = table.querySelectorAll('th');
+    let lifecycleIndex = -1;
+    
+    ths.forEach((th, idx) => {
+      if (th.textContent?.trim() === 'Lifecycle') {
+        lifecycleIndex = idx;
+        th.style.display = 'none';
+      }
+    });
+    
+    if (lifecycleIndex !== -1) {
+      table.querySelectorAll('tr').forEach(row => {
+        const cell = row.children[lifecycleIndex];
         if (cell) cell.style.display = 'none';
       });
     }
+    
+    table.dataset.processed = "1";
   });
 }
 
-// Run on load and DOM changes
+// Run on load and DOM changes (debounced)
 hideLifecycle();
-new MutationObserver(() => setTimeout(hideLifecycle, 50))
-  .observe(document.body, { childList: true, subtree: true });
+new MutationObserver(() => {
+  clearTimeout(hideTimeout);
+  hideTimeout = setTimeout(hideLifecycle, 50);
+}).observe(document.body, { childList: true, subtree: true });

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -5,5 +5,6 @@ import App from './App';
 import '@backstage/ui/css/styles.css';
 import './mobileFilterLayout.css';
 import './mermaid-init';
+import './hideLifecycle.js';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(App.createRoot());


### PR DESCRIPTION
## Summary

Hides the Lifecycle column in the catalog table using a minimal JavaScript workaround.

## Problem

The New Frontend System (v1.42.0) doesn't yet support catalog table column customization. The Lifecycle column is always visible but often not needed for our use case.

## Solution

- **Minimal JavaScript approach**: 15-line script that finds and hides the Lifecycle column by text content
- **Robust detection**: Uses text matching instead of column position for reliability
- **Dynamic handling**: MutationObserver watches for DOM changes to handle dynamic content
- **Performance optimized**: Debounced execution to avoid excessive DOM queries

## Technical Details

The solution:
1. Scans all table headers for "Lifecycle" text
2. Hides the header and corresponding column cells
3. Re-runs automatically when the DOM changes (e.g., filtering, sorting)
4. Works regardless of column position changes

## Files Changed

- `packages/app/src/hideLifecycle.js` - New minimal script
- `packages/app/src/index.tsx` - Import the script

## Future

This workaround will be removed once Backstage adds proper column customization support in the New Frontend System. Related issues:
- https://github.com/backstage/backstage/issues/17599
- https://github.com/backstage/backstage/issues/11663
- https://github.com/backstage/backstage/issues/5536

## Testing

✅ Tested locally - Lifecycle column is hidden
✅ Works with filtering and sorting
✅ Performance impact minimal